### PR TITLE
fn name in throw info

### DIFF
--- a/src/clj/peer/net.clj
+++ b/src/clj/peer/net.clj
@@ -144,7 +144,7 @@
              (reset! err* e)
              (log/error e)
              (assoc context :io.pedestal.interceptor.chain/error e)))
-         (assoc context :io.pedestal.interceptor.chain/error (ex-info "Unhandled rpc-request" (:fn request))))))})
+         (assoc context :io.pedestal.interceptor.chain/error (ex-info "Unhandled rpc-request" (select-keys request [:fn]))))))})
 
 
 (defn API-HANDLERS

--- a/src/clj/peer/net.clj
+++ b/src/clj/peer/net.clj
@@ -144,7 +144,7 @@
              (reset! err* e)
              (log/error e)
              (assoc context :io.pedestal.interceptor.chain/error e)))
-         (assoc context :io.pedestal.interceptor.chain/error (ex-info "Unhandled rpc-request" request)))))})
+         (assoc context :io.pedestal.interceptor.chain/error (ex-info "Unhandled rpc-request" (:fn request))))))})
 
 
 (defn API-HANDLERS


### PR DESCRIPTION
When a request fails because of an unhandled function, we log the entire request map which might contain sensitive information. This PR throws the method name instead.